### PR TITLE
mkmtemplate and fixsystem for esmf container

### DIFF
--- a/assimilation_code/modules/utilities/fixsystem
+++ b/assimilation_code/modules/utilities/fixsystem
@@ -77,6 +77,9 @@ fi
 if [ "$COMPILER" = gfortran ]; then
   export todo1=out
   export todo2=out
+elif [ "$COMPILER" = gfortran-9 ]; then
+  export todo1=out
+  export todo2=out
 elif [ "$COMPILER" = nagfor ]; then
   export todo1=out
   export todo2=in

--- a/build_templates/mkmf.template.esmf-container-8.6.1
+++ b/build_templates/mkmf.template.esmf-container-8.6.1
@@ -1,0 +1,146 @@
+# Template for GNU gfortran on Linux or Mac OSX
+#
+# DART software - Copyright UCAR. This open source software is provided
+# by UCAR, "as is", without charge, subject to all terms of use at
+# http://www.image.ucar.edu/DAReS/DART/DART_download
+#
+# DART $Id$
+
+# typical use with mkmf
+# mkmf -t mkmf.template.xxxx ...
+#
+# Suggested (perhaps required) flags:
+# -ffree-line-length-none   handles "long" lines - i.e. longer than 72 chars
+# -O2                       default level of code optimization
+#                           (remove for debugging)
+#
+# Suggested debugging flags:
+#  -g                  add debugging information to executable
+#  -Wuninitialized     catch uninitialized variables
+#  -Wunused            issue warning for unused variables - keeps code clean
+#  -fbacktrace         runtime errors try to print out a stack backtrace
+#  -fbounds-check      add runtime-checking for out-of-range array indices
+#  -ffpe-trap=invalid,zero,overflow
+#                      stop on floating point errors
+#
+#  Earlier versions of this mkmf file listed 'precision' as one of the options on
+#  the fpe-trap line.  This is not recommended anymore as some of the gfortran internal
+#  routines will trap, as well as some perfectly valid DART computations.
+#
+# Generally not needed but possibly useful for non-DART code:
+#
+# -ffree-form          forces input file to be read as free format regardless
+#                      of what file extension it has.
+#
+# -fdefault-real-8     force all real variables to be real*8.  not needed for DART code
+#                      since all real variables in DART are declared with a size.
+#
+# Binary (unformatted) file issues:
+# 
+#  Files which use NetCDF format (e.g. input/output ensemble member model state)
+#  automatically convert between big-endian and little-endian number formats
+#  if needed, and handle differences between single and double precision reals.
+#
+#  Ascii files (e.g. obs_seq files using ascii format, control files, scripts) 
+#  are portable between different systems. 
+# 
+#  However, binary observation sequence (obs_seq) files and other model-specific 
+#  binary files can have some or all of the following issues:
+#
+#  - Record Marker size
+#
+#     Some older versions of the gfortran compiler (including 4.1.2) changed
+#     the record marker size to 8 bytes, which made binary files written with
+#     the 'unformatted' option unreadable by programs built with other compilers.  
+#     Later versions of the compiler changed the default back to 4 bytes.
+#     If you have a version that defaults to 8 byte record markers, use this 
+#     compile time flag to write files with 4 byte markers:
+#       -frecord-marker=4
+#     If you have files written by older versions of the gfortran compiler that
+#     cannot be read now, try this compile time flag:
+#       -frecord-marker=8 
+#
+#  - Real variable precision/size:
+#
+#     If binary files are written with code that declares the variables to
+#     be real*8 (8 byte reals), which is the default in DART, the executable 
+#     that reads this file must be compiled the same way. Some DART users 
+#     redefine all DART reals to be real*4 (4 byte reals) so all code computes
+#     with and reads/writes single precision values.  In that case, all 
+#     executables must be compiled this same way to read binary (unformatted) 
+#     files successfully.  See the "types_mod.f90" file for this setting.
+#
+#  - Endian issues
+#
+#     Intel CPU chips use "little-endian" number format.  IBM Power chips
+#     use "big-endian" number format.  When binary files are written they
+#     default to writing numbers with the byte order native to the machine.  
+#
+#     To read DART observation sequence (obs_seq) binary files on a 
+#     computing platform with a different "endian-ness":
+#
+#       There is a runtime namelist item in the &obs_sequence_nml namelist 
+#       to set a different endian for the observation sequence files only.
+#       This is the recommended way to read binary obs_seq files if written
+#       by a different platform.  Options:  big_endian, little_endian, native.
+# 
+#     To read other model-specific binary files on a different platform:
+#
+#       You can convert big-endian or little-endian binary files at runtime
+#       on a unit-number by unit-number basis.  Note that if you set all
+#       open file units to a different endian-ness, any new files you write
+#       will also have that same endian-ness. You may need to add some print 
+#       statements in the code after opening the file to determine which 
+#       unit numbers are being used.  You can then set them in the environment
+#       to override the default:
+#
+#       setenv GFORTRAN_CONVERT_UNIT 'big_endian'
+#         Treats ALL open file units as big_endian.  (Not recommended if new files
+#         will be written.)  Options:  big_endian, little_endian, native.
+#
+#       setenv GFORTRAN_CONVERT_UNIT 'big_endian;native:10-20'
+#         Treats file units 10-20 as native; the rest are 'big_endian' 
+#
+#       For more information on unit conversions:
+#        http://gcc.gnu.org/onlinedocs/gfortran/GFORTRAN_005fCONVERT_005fUNIT.html
+#
+
+
+MPIFC = mpif90
+MPILD = mpif90
+FC = gfortran-9
+LD = gfortran-9
+
+# DISCUSSION ABOUT NETCDF. DART works with both V3 and V4 flavors of netCDF.
+# Some V4 installations also require the HDF5 libraries. Some don't.
+# Some netCDF installations require both -lnetcdff and -lnetcdf, some only
+# require -lnetcdf. The permutations make it difficult to cover the possible
+# installations. Here are some candidates, you might just have to resort to
+# trial and error:
+# LIBS = -L$(NETCDF)/lib -lnetcdf
+# LIBS = -L$(NETCDF)/lib -lnetcdff -lnetcdf
+# LIBS = -L$(NETCDF)/lib -lnetcdf           -lcurl -lhdf5_hl -lhdf5 -lz -lm
+# LIBS = -L$(NETCDF)/lib -lnetcdff -lnetcdf -lcurl -lhdf5_hl -lhdf5 -lz -lm
+#
+# If you get an error "ld: library not found for -lnetcdff" (note 2 f's),
+# remove it from the LIBS line. The same is true for any library. If 'ld'
+# does not complain - it worked.
+
+# If your NETCDF environment variable is not set correctly,
+# uncomment the following line and set value to where lib and include
+# are found for the netcdf files that match this compiler.
+#
+NETCDF = /home/dev/stack/netcdf-4.7.4
+
+INCS = -I$(NETCDF)/include
+LIBS = -L$(NETCDF)/lib -lnetcdff -lnetcdf
+FFLAGS  = -O2 -ffree-line-length-none $(INCS)
+LDFLAGS = $(FFLAGS) $(LIBS)
+
+# FFLAGS = -g -Wuninitialized -Wunused -ffree-line-length-none -fbounds-check \
+#          -fbacktrace -ffpe-trap=invalid,zero,overflow $(INCS)
+
+# <next few lines under version control, do not edit>
+# $URL$
+# $Revision$
+# $Date$

--- a/build_templates/mkmf.template.esmf-container-8.6.1
+++ b/build_templates/mkmf.template.esmf-container-8.6.1
@@ -130,10 +130,10 @@ LD = gfortran-9
 # uncomment the following line and set value to where lib and include
 # are found for the netcdf files that match this compiler.
 #
-NETCDF = /home/dev/stack/netcdf-4.7.4
+NETCDF = /home/dev/spack/opt/spack/linux-ubuntu20.04-aarch64/gcc-9.4.0/netcdf-fortran-4.4.5-iwk5z2hftdaqhqowqdmvo2bkxo64p3ad
 
 INCS = -I$(NETCDF)/include
-LIBS = -L$(NETCDF)/lib -lnetcdff -lnetcdf
+LIBS = -L$(NETCDF)/lib -lnetcdff #-lnetcdf
 FFLAGS  = -O2 -ffree-line-length-none $(INCS)
 LDFLAGS = $(FFLAGS) $(LIBS)
 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Added an mkmf.template for building DART in the esmf container esmf/esmf-build-release:8.6.1
https://hub.docker.com/r/esmf/esmf-build-release

the gfortran compiler in the container is named gfortran-9 so I updated fixsytem to accept gfortran or gfortran-9

### Fixes issue
<!--- link to github issue(s) -->
#1 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Built dart in the  esmf/esmf-build-release:8.6.1 container.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
